### PR TITLE
CPV update for hidden information

### DIFF
--- a/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
+++ b/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
@@ -944,7 +944,7 @@ A backup may be considered to the point of the action, not the erroneous communi
 
 **3.7A. Definition**
 
-In a Multiplayer Tournament, physically revealing hidden information is allowed in certain conditions (see MAMTR 3.13 Hidden Information). Secretly exchanging hidden information with an Opponent is a Communication Policy Violation (see MAMTR 4.1 - Player Communication).
+In a Multiplayer Tournament, physically revealing hidden information is allowed in certain conditions (see [MAMTR 3.13 Hidden Information](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr#313-hidden-information)). Secretly exchanging hidden information with an Opponent is a Communication Policy Violation (see [MAMTR 4.1 - Player Communication](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr#41-player-communication)).
 
 **3.7B. Examples**
 

--- a/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
+++ b/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
@@ -944,7 +944,7 @@ A backup may be considered to the point of the action, not the erroneous communi
 
 **3.7A. Definition**
 
-In a Multiplayer Tournament, physically revealing hidden information is allowed in certain conditions. Failing to comply to that policy is a Communication Policy Violation. This also includes showing hidden information to a specific opponent while not revealing it to the remaining players.
+In a Multiplayer Tournament, physically revealing hidden information is allowed in certain conditions (see MAMTR 3.13 Hidden Information). Secretly exchanging hidden information with an Opponent is a Communication Policy Violation (see MAMTR 4.1 - Player Communication).
 
 **3.7B. Examples**
 

--- a/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
+++ b/docs/_posts/2024-09-27-multiplayer-addendum-infraction-procedure-guide.markdown
@@ -890,6 +890,74 @@ players.
 
 **3.5B. Additional Remedy** In Multiplayer Tournaments, it's possible for multiple cards to be missing by be located in multiple players' decks. If the missing card(s) were in a previous or current opponent’s deck(s), issue **penalties to all involved players**.
 
+## 3.7. Communication Policy Violation
+
+<details markdown="0">
+  <summary><strong>Original policy</strong></summary>
+  <blockquote>
+    <strong style="float:right; border: 1px solid black; padding: 0px 15px;">Warning</strong>
+    <p>
+      <strong>Definition</strong>
+    </p>
+    <p>
+A player violates the Communication policies detailed in section 4 of the Magic Tournament
+Rules and the judge believes their opponent has taken an in-game action or clearly chosen not to
+act based on the erroneous information. This infraction only applies to violations of that policy
+and not to general communication confusion.
+    </p>
+    <p>
+      <strong>Examples</strong>
+    </p>
+    <ol type="A">
+     <li>A player is asked how many cards they have in their hand and answers “Three.” A few moments later, their opponent casts a discard spell and they realize that they have four.</li>
+     <li>A player keeps their Llanowar Elf in with their land, and their opponent attacks thinking they have no blockers.</li>
+     <li>A player casts Path to Exile, forgets to remind their opponent that they have the opportunity to search for a basic land and, as a result, they don’t.</li>
+    </ol>
+    <p>
+      <strong>Philosophy</strong>
+    </p>
+    <p>
+Clear communication is essential when playing Magic. Though many offenses will be
+intentional, it is possible for a player to make a genuine mistake that causes confusion and these
+should not be penalized harshly.
+      </p>
+    <p>
+A player may commit this infraction in situations where they have not spoken. A physically
+ambiguous board state is not automatically a penalty, but judges are encouraged to tell players to
+fix ambiguous placements before they might become problematic.
+      </p>
+    <p>
+Misapplication of a shortcut is usually not a Communication Policy Violation, as the default
+interpretation applies in ambiguous situations and the opponent is able to act on that shortcut.
+Any deviation from a tournament shortcut requires a clear explanation.
+</p>
+    <p><strong>
+Additional Remedy
+      </strong></p>
+    <p>
+A backup may be considered to the point of the action, not the erroneous communication.
+</p>
+  </blockquote>
+</details>
+
+**Policy Additions**
+
+**3.7A. Definition**
+
+In a Multiplayer Tournament, physically revealing hidden information is allowed in certain conditions. Failing to comply to that policy is a Communication Policy Violation. This also includes showing hidden information to a specific opponent while not revealing it to the remaining players.
+
+**3.7B. Examples**
+
+Anton is about to win a match between them, Bart, Cicero and Danika. While Bart has priority, and before they make a decision, Cicero shows them a card from their hand. This is a Communication Policy Violation.
+
+**3.7C. Philosophy**
+
+In Multiplayer Tournaments, Communication Policy Violation Warnings exist as a deterrence for Collusion, and because it's admissible that some Players are unaware of the Policy. In addition to the Warning we also have an additional remedy to mitigate any potential advantage gained.
+
+**3.7D. Additional Remedy**
+
+In the case where hidden information could be legally revealed and instead is shown only to a subset of players, that information must be revealed to all players. If it's not possible to determine the exact piece of information shown (i.e.: the actual card face) because its part of a larger hidden set, the entire set is revealed.
+
 # 4. Unsporting Conduct
 
 ## 4.1. Unsporting Conduct — Minor


### PR DESCRIPTION
This came from a discussion on discord, where we realized we had no decent fix or even agreed penalty for when a player not aware of the policy shows a card to an opponent, perhaps in hope of making it easier to stop a third player from winning.

Since this is allowed under other rulesets and not under this one, we needed to make it clear what the penalty would be.

Our discussion went more or less like this:

A player questioned the ruling if someone reveals a card to another player and suggests calling a judge. They believe that, in such cases, the card should be shown to everyone at the table. The judge explained that without a clear admission, it’s tough to prove a reveal occurred, making it one player's word against another. They’d analyze if the reveal could provide any strategic advantage before deciding.

If a player admits to an unintentional reveal, they would typically receive a warning rather than a penalty, provided it wasn’t part of collusion. However, if a player misleads the judge for advantage, it’s grounds for disqualification. While the suggestion to reveal to everyone is understandable, the judge noted it could be abused and clarified that such a case might be handled as a "communication policy violation," escalating to game loss if repeated.

In the follow-up, Rôxo proposes three potential rulings for cases where a player reveals a card to only one opponent:

- Treat it as a Hidden Card Error (HCE), which would mean revealing the hand to all players. While fair, it’s philosophically misaligned, as HCE addresses gameplay errors rather than policy violations.
- Consider it a Communication Policy Violation (CPV), which aligns better but lacks a clear fix. Rôxo suggests adding a CPV-specific remedy where the hand would be revealed to all to ensure fairness.
- Classify it as Unsporting Conduct - Minor, which would issue a warning but not fully address the situation’s impact.

The discussion shifts toward favoring CPV with a tailored fix to reveal all cards if public knowledge doesn’t clarify the revealed card(s). Fábio agrees and plans to propose a policy update, though implementing it just before a major tournament poses logistical challenges.

(thanks chatgpt for summarizing the conversation and making it more anonymous)