### PR TITLE
Disallow "restarts" in swiss rounds

### DIFF
--- a/docs/_posts/2025-12-09-multiplayer-addendum-infraction-procedure-guide.markdown
+++ b/docs/_posts/2025-12-09-multiplayer-addendum-infraction-procedure-guide.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Multiplayer Addendum to the Infraction Procedure Guide"
-date: 2026-04-27 1:00:00 +0000
+date: 2026-06-22 1:00:00 +0000
 categories: unofficial documents multiplayer competitive
 permalink: multiplayer-addendum-ipg
 ---
@@ -991,6 +991,49 @@ the offense is repeated at a later time, the penalty is Disqualification and rem
 **4.2E. Upgrade**: In Multiplayer Tournaments, if it is determined that players in Collusion with each other were aware that what they were doing was not permitted, or they acted with malicious intent, the penalty is Disqualification. All players found in Collusion receive this penalty.
 
 **4.2F. Upgrade**: In Multiplayer Tournaments, if it is determined that a player performed a Spite Play while aware it was not permitted, or they acted with malicious intent, the penalty is Disqualification.
+
+## 4.3 Unsporting Conduct - Improperly Determining a Winner
+
+<details markdown="0">
+  <summary><strong>Original policy</strong></summary>
+  <blockquote>
+    <strong style="float:right; border: 1px solid black; padding: 0px 15px;">Match Loss</strong>
+    <p>
+      <strong>Definition</strong>
+    </p>
+    <p>
+      A player uses or offers to use a method that is not part of the current game (including actions not legal in the current game) to determine the outcome of a game or match.
+    </p>
+    <p>
+      If the player was aware that what they were doing was against the rules, the infraction is Unsporting Conduct – Cheating
+    </p>
+    <p>
+      <strong>Examples</strong>
+    </p>
+    <ol>
+      <li>As time is called, two players about to draw roll a die to determine the winner.</li>
+      <li>A player offers to flip a coin to determine the winner of a match.</li>
+      <li>Two players arm wrestle to determine the winner of the match.</li>
+      <li>Two players play rock-paper-scissors to decide if they should play the match or draw.</li>
+      <li>Two players compare the converted mana costs of the top cards of their libraries to determine the winner of a game at the end of extra turns.</li>
+      <li>Two players reveal cards from the top of their libraries to see “who would win” after extra turns.</li>
+      <li>A player says “Oh no, we’re going to draw, that is terrible for us.  If only there were something we could do about it.”</li>
+    </ol>
+    <p>
+      <strong>Philosophy</strong>
+    </p>
+    <p>Using an outside-the-game method to determine a winner compromises the integrity of the tournament.</p>
+    <p>Matches that result in a draw due to time are expected to be reported as such and are not excluded from this penalty if the players use an illegal method to determine the outcome.</p>
+  </blockquote>
+</details>
+
+**Policy Additions** 
+
+**4.3A. Definition** In Multiplayer Tournaments, not respecting a rule that limits the number of Games played in a Match is also Unsporting Conduct - Improperly Determining a Winner.
+
+**4.3A. Examples**
+
+1. In the Swiss portion of a Multiplayer Tournament with the requirement of playing a single Game, players agree to Draw and one of them suggests that since they still have 45 minutes left on the Round timer, that they should play another Game to determine the winner.
 
 ## 4.4. Unsporting Conduct — Bribery and Wagering
 

--- a/docs/_posts/2026-03-26-multiplayer-addendum-magic-tournament-rules.markdown
+++ b/docs/_posts/2026-03-26-multiplayer-addendum-magic-tournament-rules.markdown
@@ -853,7 +853,10 @@ Refer to the official banlist available at [Wizard's of the Coast official websi
 
 ## x.1 Match Structure
 
-**x.1A** In Commander Matches, the required number of Game wins to win a Match is one. As per 2.1, a Match continues until the required number of Game wins is attained by a Player or ends in a Draw.
+**x.1A** In Commander Tournaments, the required number of Game wins to win a Match is one (check section 2.1 Match Structure):
+
+- During the Swiss portion of the event, if a Game ends in a Draw, the Match immediately ends in a Draw and no new Games can be played in the Match.
+- During the Single Elimination portion of the Event, a Match continues until the required number of Game wins is attained by a Player or ends in a Draw.
 
 **x.1B** In Commander Matches, Players play against each other in Pods. Each Pod should be composed of four Players. In the case that the number of participants is not divisible by 4, it is recommended that the minimum possible number of Pods with three Players be used in order to not have any Byes. 
 

--- a/docs/_posts/2026-03-26-multiplayer-addendum-magic-tournament-rules.markdown
+++ b/docs/_posts/2026-03-26-multiplayer-addendum-magic-tournament-rules.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Multiplayer Addendum to the Magic Tournament Rules"
-date: 2026-04-26 1:00:00 +0000
+date: 2026-06-22 1:00:00 +0000
 categories: unofficial documents multiplayer competitive regular
 permalink: multiplayer-addendum-mtr
 ---
@@ -202,11 +202,15 @@ _Example: Alice, Bob, Charles and Dani are playing a Best-of-One Multiplayer Mat
 
 **Policy Additions**
 
-**2.1A** In Multiplayer Tournaments, the usual number of Games required to win a Match is one. If a Game ends in a Draw, a new Game is started including every Player in the Pod.
+**2.1A** In Multiplayer Tournaments, the usual number of Games required to win a Match is one.
 
 The winner of a Match is the Player that won the required number of Games, or the Player that has won the most Games.
 
 In the case of a tie, the Match is a Draw between the Players that participated in that Match, with the exception of Players that received Match Loss penalties or Players that conceded the Match.
+
+**2.1B** In Multiplayer Tournaments, during the Swiss portion of the event where the required number of Games to Win a Match is one, if a Game ends in a Draw, the Match immediately ends in a Draw with not more games allowed to be played in the Match.
+
+**2.1C** In Multiplayer Tournaments, during the Single Elimination portion of the event, If a Game ends in a Draw, a new Game is started including every Player in the Pod.
 
 ## 2.2 Play/Draw Rule
 
@@ -316,7 +320,7 @@ _Example: Alice, Bob, Charlie, and Daniel are playing in a Multiplayer Match. Al
 
 In order to enforce a fast pace during the last turn, a **last turn time limit** is applied. If the **last turn time limit** is reached before a winner is determined, the Match immediately ends with the current Game as a Draw. Thus said, the players still have agency to concede and determine a Winner at this point, as long as they don't do it improperly (see Improperly Determining a Winner in the Infraction Procedure Guide).
 
-_Example: Arnold, Benjamin, Cam, and Durbin are playing in a Multiplayer Match. Time in the Round has been called. Cam is the active Player when the last turn time limit is reached. Since no winner has been declared, the Match with the current Game as a Draw._
+_Example: Arnold, Benjamin, Cam, and Durbin are playing in a Multiplayer Match. Time in the Round has been called. Cam is the active Player when the last turn time limit is reached. Since no winner has been declared, the Match ends with the current Game as a Draw._
 
 **2.4C** In Multiplayer Tournaments, in the case a Single Elimination Match results in a Draw, the Player with the highest Standing from the Swiss Portion of the event should be considered the Winner. In the case where a player advances to the next stage of Single Elimination due to a Match Draw, their seating in the next rounds will be affected, no longer depending only on the standings from the Swiss portion of the event.
 


### PR DESCRIPTION
This PR aims to disable individual Game Draws during swiss rounds.

The reasoning behind this decision is to prevent "dark" play patterns where players blindly go for the win because they know in the worst case scenario they get a restart. And the pattern where players in 4th position play for a restart until they get a really great starting hand to try and win uncontested.

This was the result of a survey that consulted player sentiment and voted to be implemented by the current European commission of tournament organizers..